### PR TITLE
Replce FIles.exists? to exist?

### DIFF
--- a/lib/files.rb
+++ b/lib/files.rb
@@ -99,7 +99,7 @@ module Files
     end
 
     def remove
-      FileUtils.rm_rf(@root) if File.exists?(@root)
+      FileUtils.rm_rf(@root) if File.exist?(@root)
     end
 
     private


### PR DESCRIPTION
When I run, rspec to [annotate_models](https://github.com/ctran/annotate_models) with `RUBYOPT="-w"`.
I found `warning: File.exists? is a deprecated name, use File.exist? instead`.
